### PR TITLE
Update pdfpic.tmac

### DIFF
--- a/tmac/pdfpic.tmac
+++ b/tmac/pdfpic.tmac
@@ -84,7 +84,7 @@
 .\" get image dimensions
 .  ec @
 .  sy pdfinfo @$1 | \
-grep "Page *size" | \
+grep -a "Page *size" | \
 sed -e 's/Page *size: *\\([[:digit:].]*\\) *x *\\([[:digit:].]*\\).*$/\
 .nr pdf-wid (p;\\1)\\n\
 .nr pdf-ht  (p;\\2)/' \


### PR DESCRIPTION
Had a problem with this on ubuntu 22.04
grep failed on: grep: (standard input): binary file matches output of pdfinfo